### PR TITLE
async-tree should not cache isInitialChanged

### DIFF
--- a/addon/components/async-tree.js
+++ b/addon/components/async-tree.js
@@ -20,16 +20,10 @@ export default Component.extend(ResizeAware, {
   'row-height': 20,
   indentation: 20,
 
-  isInitialChanged: computed(
-    'initial',
-    '_initial',
-    'initial-filter',
-    '_initial-filter', {
-      get() {
-        return this.get('initial') !== this.get('_initial') ||
-               this.get('initial-filter') !== this.get('_initial-filter');
-      }
-  }),
+  checkInitialChanged() {
+    return this.get('initial') !== this.get('_initial') ||
+           this.get('initial-filter') !== this.get('_initial-filter');
+  },
 
   visibleNodes: computed(
     '_root',
@@ -88,7 +82,7 @@ export default Component.extend(ResizeAware, {
   },
 
   updateInitial() {
-    if (this.get('isInitialChanged')) {
+    if (this.checkInitialChanged()) {
       let initial = this.get('initial');
       let initialFilter = this.get('initial-filter');
       let { root, openNodes } = Node.load(initial, initialFilter);
@@ -127,7 +121,8 @@ export default Component.extend(ResizeAware, {
 
   updateFlattened() {
     let root = this.get('_root');
-    this.set('_flattened', root.flatten());
+    let flattened = root.flatten();
+    this.set('_flattened', flattened);
   },
 
   addChildren(node, children) {

--- a/addon/tests/page-object.js
+++ b/addon/tests/page-object.js
@@ -36,7 +36,7 @@ export default class AsyncTreePageObject {
     return items.find(`.node-list-item:contains('${text}')`);
   }
 
-  find(selector) {
+  find() {
     let component = this.component();
     return component.find(...arguments);
   }

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "ember-load-initializers": "0.1.7",
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "material-design-lite-src": "https://github.com/google/material-design-lite.git#37286ae139b0ae336a8a7e9ed3b18ace1abff7ed",
     "material-design-lite": "~1.0.0",

--- a/tests/acceptance/infinite-scroll-test.js
+++ b/tests/acceptance/infinite-scroll-test.js
@@ -1,18 +1,37 @@
-// import Ember from 'ember';
-// import { module, test } from 'qunit';
-// import startApp from 'dummy/tests/helpers/start-app';
-//
-// module('Acceptance: Infinite Scroll', {
-//   beforeEach: function() {
-//     this.application = startApp();
-//   },
-//
-//   afterEach: function() {
-//     Ember.run(this.application, 'destroy');
-//   }
-// });
-//
-// test('tree rendering', function(assert) {
-//   visit('/infinite-scroll');
-//
-// });
+import Ember from 'ember';
+import { module, test} from 'qunit';
+import startApp from 'dummy/tests/helpers/start-app';
+
+module('Acceptance: Infinite Scroll', {
+  beforeEach: function() {
+    this.application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(this.application, 'destroy');
+  }
+});
+
+test('tree rendering', function(assert) {
+  assert.expect(3);
+  visit('/infinite-scroll');
+  assert.equal(find('.node-list-item').length, 0, 'has 0 elements at beginning');
+
+  andThen(() => {
+    assert.equal(find('.node-list-item').length, 50, 'has 50 elements');
+    let scrollEl = find('.infinite-scroll-container .async-tree .node-list');
+
+    // Because ember test suite shrinks viewport, relocate the scroll element
+    // to assure triggering async-more
+    scrollEl.css('position', 'fixed');
+    scrollEl.css('top', 0);
+    scrollEl.css('left', 0);
+    let scroll = scrollEl[0];
+    scroll.scrollTop = scroll.scrollHeight;
+  });
+
+  andThen(() => {
+    assert.equal(find('.node-list-item').length, 100, 'has 100 elements');
+  });
+
+});

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -6,6 +6,9 @@
   .node-list {
     list-style: none;
     padding-left: 10px;
+    width: 400px;
+    height: 300px;
+    overflow-y: scroll;
   }
   .node-label:before {
     display: inline-block;


### PR DESCRIPTION
I found infinite scroll dummy page doesn't work because of async-tree is caching `isInitialChanged`. This happens because the computed key `initial` and `_initial` are arrays, if it is same array object and same size, Ember won't be able to know it has been changed.