### PR TITLE
Support for expanding nested nodes.

### DIFF
--- a/addon/components/async-tree.js
+++ b/addon/components/async-tree.js
@@ -141,7 +141,13 @@ export default Component.extend(ResizeAware, {
 
   openNode(node) {
     let openNodes = this.get('openNodes');
-    this.set('openNodes', openNodes.concat(node));
+    let onOpen = this.get('on-open');
+    if (onOpen) {
+      openNodes = onOpen(node, openNodes);
+    } else {
+      openNodes = openNodes.concat(node);
+    }
+    this.set('openNodes', openNodes);
   },
 
   closeNode(node) {

--- a/addon/tests/page-object.js
+++ b/addon/tests/page-object.js
@@ -36,7 +36,7 @@ export default class AsyncTreePageObject {
     return items.find(`.node-list-item:contains('${text}')`);
   }
 
-  find(selector) {
+  find() {
     let component = this.component();
     return component.find(...arguments);
   }
@@ -44,6 +44,10 @@ export default class AsyncTreePageObject {
   findIndex(selector, predicate) {
     let results = this.find(selector).toArray();
     return indexOf(results, predicate);
+  }
+
+  open(name) {
+    this.env.$(`.node-label:contains(${name})`).click();
   }
 
   isOpenItem(name) {

--- a/addon/utils/node.js
+++ b/addon/utils/node.js
@@ -7,6 +7,7 @@ import intersection from 'lodash/array/intersection';
 
 const {
   isEmpty,
+  isNone,
   isPresent,
   set
 } = Ember;
@@ -34,10 +35,24 @@ export default class Node {
   }
 
   addChild(item) {
+
+    let children;
+
+    if (!isNone(item.content) && !isNone(item.children)) {
+      children = item.children;
+      item = item.content;
+    }
+
     let node = new Node({
       content: item,
       depth: this.depth + 1
     }, this);
+
+    if (!isNone(children)) {
+      node.markLoaded();
+      node.addChildren(children);
+    }
+
     this.children.set(item, node);
     return node;
   }

--- a/tests/integration/initial-test.js
+++ b/tests/integration/initial-test.js
@@ -117,3 +117,33 @@ test('no data uses inverse template', function(assert){
   assert.ok(!this.asyncTree.isEmpty(), 'async tree is not empty');
   assert.equal(this.asyncTree.emptyText(), '', 'Inverse message is empty');
 });
+
+test('setting an on-open action changes the open nodes list', function(assert){
+  this.render(hbs`
+    {{#async-tree
+      initial=initial
+      on-open=appendNodes
+      fetch=fetchChildren
+      as |node|}}
+      {{node.name}}
+    {{/async-tree}}
+  `);
+
+  this.set('initial', [ FIRST_PARENT ]);
+  this.set('fetchChildren', () => [ FIRST_CHILD, FIRST_GRANDCHILD ]);
+  this.set('appendNodes', (node, openNodes) => openNodes.concat(node));
+
+  assert.deepEqual(this.asyncTree.itemsText(), [
+    'first parent',
+  ]);
+  assert.ok(this.asyncTree.isNotOpenItem('first parent'));
+
+  // open the node.
+  this.asyncTree.open('first parent');
+  assert.ok(this.asyncTree.isOpenItem('first parent'));
+  assert.deepEqual(this.asyncTree.itemsText(), [
+    'first parent',
+    'first child',
+    'first grandchild'
+  ]);
+});

--- a/tests/unit/async-tree-component-test.js
+++ b/tests/unit/async-tree-component-test.js
@@ -19,7 +19,7 @@ const {
 
 module('unit: async-tree component');
 
-test('flattened data is ordered correctly when initial data is chagned', function(assert){
+test('flattened data is ordered correctly when initial data is changed', function(assert){
 
   let component = AsyncTreeComponent.create();
 

--- a/tests/unit/node-test.js
+++ b/tests/unit/node-test.js
@@ -147,6 +147,76 @@ test('node.parents() returns array of parents', function(assert){
 
 });
 
+test('node.addChildren() should add children', function(assert){
+
+  let root = new Node();
+  let result = root.addChildren([ FIRST_PARENT ]);
+  assert.deepEqual(getNames(result), [ 'first parent' ]);
+
+  let [ firstParent ] = result;
+  let children = firstParent.addChildren([ FIRST_CHILD, SECOND_CHILD ]);
+
+  assert.deepEqual(getNames(children), ['first child', 'second child']);
+});
+
+test('node.addChildren() should add children and grandchildren', function(assert){
+  assert.expect(14);
+
+  let root = new Node();
+  let result = root.addChildren([
+    {
+      content: FIRST_PARENT,
+      children: [
+        FIRST_CHILD, SECOND_CHILD
+      ]
+    }
+  ]);
+
+  let [ parentNode ] = result;
+  let children = parentNode.getChildren();
+
+  assert.ok(parentNode.isLoaded, 'parent node is marked as loaded');
+  assert.equal(children.length, 2, '2 children were added to parent node');
+  assert.deepEqual(getNames(children), ['first child', 'second child']);
+
+  root = new Node();
+
+  result = root.addChildren([
+    {
+      content: FIRST_PARENT,
+      children: [
+        {
+          content: FIRST_CHILD,
+          children: [ FIRST_GRANDCHILD ]
+        },
+        {
+          content: SECOND_CHILD,
+          children: [ SECOND_GRANDCHILD ]
+        }
+      ]
+    }
+  ]);
+
+  [ parentNode ] = result;
+  let [ firstChild, secondChild ] = parentNode.getChildren();
+  let firstGrandchildren = firstChild.getChildren();
+  let secondGrandchildren  = secondChild.getChildren();
+
+  assert.ok(parentNode.isLoaded, 'parent node is marked as loaded');
+
+  assert.ok(firstChild, 'first child is present');
+  assert.ok(firstChild.isLoaded, 'first child is marked as loaded');
+  assert.ok(secondChild, 'second child is present');
+  assert.ok(secondChild.isLoaded, 'second child is marked as loaded');
+
+  assert.equal(firstGrandchildren.length, 1, 'first child has one grandchild');
+  assert.notOk(firstGrandchildren.isLoaded, 'first grandchild is not loaded');
+  assert.equal(secondGrandchildren.length, 1, 'second child has one grandchild');
+  assert.notOk(secondGrandchildren.isLoaded, 'second grandchild is not loaded');
+  assert.deepEqual(getNames(firstGrandchildren), ['first grandchild' ]);
+  assert.deepEqual(getNames(secondGrandchildren), ['second grandchild' ]);
+});
+
 function getNames(nodes) {
   return nodes.map(function(node){
     return get(node, 'content.name');


### PR DESCRIPTION
This PR adds support for expanding nested nodes at once, via use of a new action, `on-open` and modifications to `addChild`. Three new tests are also included.